### PR TITLE
feat: support platform tags with go bin for android and java

### DIFF
--- a/cmd/gomobile/bind_androidapp.go
+++ b/cmd/gomobile/bind_androidapp.go
@@ -33,7 +33,8 @@ func goAndroidBind(gobind string, pkgs []*packages.Package, targets []targetInfo
 	cmd.Env = append(cmd.Env, "GOOS=android")
 	cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 	if len(buildTags) > 0 {
-		cmd.Args = append(cmd.Args, "-tags="+strings.Join(buildTags, ","))
+		tags := append(buildTags[:], platformTags("android")...)
+		cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
 	}
 	if bindJavaPkg != "" {
 		cmd.Args = append(cmd.Args, "-javapkg="+bindJavaPkg)

--- a/cmd/gomobile/bind_androidapp.go
+++ b/cmd/gomobile/bind_androidapp.go
@@ -33,8 +33,8 @@ func goAndroidBind(gobind string, pkgs []*packages.Package, targets []targetInfo
 	cmd.Env = append(cmd.Env, "GOOS=android")
 	cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
 	if len(buildTags) > 0 {
-		tags := append(buildTags[:], platformTags("android")...)
-		cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
+		buildTags = append(buildTags, platformTags("android")...)
+		cmd.Args = append(cmd.Args, "-tags="+strings.Join(buildTags, ","))
 	}
 	if bindJavaPkg != "" {
 		cmd.Args = append(cmd.Args, "-javapkg="+bindJavaPkg)

--- a/cmd/gomobile/bind_javaapp.go
+++ b/cmd/gomobile/bind_javaapp.go
@@ -27,8 +27,8 @@ func goJavaBind(gobind string, pkgs []*packages.Package, targets []targetInfo) e
 		"-outdir="+tmpdir,
 	)
 	if len(buildTags) > 0 {
-		tags := append(buildTags[:], platformTags("java")...)
-		cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
+		buildTags = append(buildTags[:], platformTags("java")...)
+		cmd.Args = append(cmd.Args, "-tags="+strings.Join(buildTags, ","))
 	}
 	if bindJavaPkg != "" {
 		cmd.Args = append(cmd.Args, "-javapkg="+bindJavaPkg)

--- a/cmd/gomobile/bind_javaapp.go
+++ b/cmd/gomobile/bind_javaapp.go
@@ -27,7 +27,7 @@ func goJavaBind(gobind string, pkgs []*packages.Package, targets []targetInfo) e
 		"-outdir="+tmpdir,
 	)
 	if len(buildTags) > 0 {
-		tags := append(buildTags[:], platformTags("android")...)
+		tags := append(buildTags[:], platformTags("java")...)
 		cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
 	}
 	if bindJavaPkg != "" {

--- a/cmd/gomobile/bind_javaapp.go
+++ b/cmd/gomobile/bind_javaapp.go
@@ -27,7 +27,8 @@ func goJavaBind(gobind string, pkgs []*packages.Package, targets []targetInfo) e
 		"-outdir="+tmpdir,
 	)
 	if len(buildTags) > 0 {
-		cmd.Args = append(cmd.Args, "-tags="+strings.Join(buildTags, ","))
+		tags := append(buildTags[:], platformTags("android")...)
+		cmd.Args = append(cmd.Args, "-tags="+strings.Join(tags, ","))
 	}
 	if bindJavaPkg != "" {
 		cmd.Args = append(cmd.Args, "-javapkg="+bindJavaPkg)


### PR DESCRIPTION
This diff aims to support go tags while building with oomobile. We set up the env with android and java tags based on the respective platform. However, when binding, we do not pass in these tags which prevents detection of several C symbols. This diff should fix the issue.

Part of https://github.com/ooni/probe-cli/issues/1716